### PR TITLE
Increase maximum number of hits for /v2/filter to 500

### DIFF
--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rundsk/dsk/internal/ddt"
 )
 
-const FILTER_RESULT_LIMIT = 500
+const FilterResultLimit = 500
 
 var (
 	// AvailableSearchLangs are languages mapped to their analyzer names.

--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/rundsk/dsk/internal/ddt"
 )
 
+const FILTER_RESULT_LIMIT = 500
+
 var (
 	// AvailableSearchLangs are languages mapped to their analyzer names.
 	AvailableSearchLangs = map[string]string{
@@ -382,7 +384,7 @@ func (s *Search) FilterSearch(q string) ([]*ddt.Node, int, time.Duration, bool, 
 
 	cq := bleve.NewConjunctionQuery(pqs...)
 	req := bleve.NewSearchRequest(cq)
-	req.Size = 100
+	req.Size = FILTER_RESULT_LIMIT
 
 	res, err := s.narrowIndex.Search(req)
 

--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rundsk/dsk/internal/ddt"
 	"github.com/blevesearch/bleve"
 	"github.com/blevesearch/bleve/analysis/analyzer/keyword"
 	"github.com/blevesearch/bleve/analysis/analyzer/simple"
@@ -23,6 +22,7 @@ import (
 	"github.com/blevesearch/bleve/analysis/lang/en"
 	"github.com/blevesearch/bleve/mapping"
 	"github.com/blevesearch/bleve/search/query"
+	"github.com/rundsk/dsk/internal/ddt"
 )
 
 var (
@@ -382,6 +382,7 @@ func (s *Search) FilterSearch(q string) ([]*ddt.Node, int, time.Duration, bool, 
 
 	cq := bleve.NewConjunctionQuery(pqs...)
 	req := bleve.NewSearchRequest(cq)
+	req.Size = 100
 
 	res, err := s.narrowIndex.Search(req)
 

--- a/internal/search/main.go
+++ b/internal/search/main.go
@@ -384,7 +384,7 @@ func (s *Search) FilterSearch(q string) ([]*ddt.Node, int, time.Duration, bool, 
 
 	cq := bleve.NewConjunctionQuery(pqs...)
 	req := bleve.NewSearchRequest(cq)
-	req.Size = FILTER_RESULT_LIMIT
+	req.Size = FilterResultLimit
 
 	res, err := s.narrowIndex.Search(req)
 

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -7,6 +7,7 @@
 package search
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -561,6 +562,54 @@ func TestFilterSearchTagsWithSpacesWhenTitleContainsSpace(t *testing.T) {
 
 	rs, _, _, _, _ = s.FilterSearch("needs images")
 	expectFilterSearchResult(t, rs, "Color-Definition")
+}
+
+func TestFilterSearchMoreThan10Results(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "tree")
+
+	var nodes []*ddt.Node
+	for i := 0; i < 20; i++ {
+		n0 := newTestNode(filepath.Join(tmp, fmt.Sprintf("Node-%d", i)), tmp)
+		n0.Create()
+		n0.CreateMeta("meta.yaml", &ddt.NodeMeta{
+			Tags: []string{"foo"},
+		})
+		n0.Load()
+
+		nodes = append(nodes, n0)
+	}
+
+	s := setupSearchTest(t, tmp, "en", []*ddt.Node{
+		nodes[0],
+		nodes[1],
+		nodes[2],
+		nodes[3],
+		nodes[4],
+		nodes[5],
+		nodes[6],
+		nodes[7],
+		nodes[8],
+		nodes[9],
+		nodes[10],
+		nodes[11],
+		nodes[12],
+	}, false)
+	defer teardownSearchTest(tmp, s)
+
+	rs, _, _, _, _ := s.FilterSearch("foo")
+	expectFilterSearchResult(t, rs, "Node-0")
+	expectFilterSearchResult(t, rs, "Node-1")
+	expectFilterSearchResult(t, rs, "Node-2")
+	expectFilterSearchResult(t, rs, "Node-3")
+	expectFilterSearchResult(t, rs, "Node-4")
+	expectFilterSearchResult(t, rs, "Node-5")
+	expectFilterSearchResult(t, rs, "Node-6")
+	expectFilterSearchResult(t, rs, "Node-7")
+	expectFilterSearchResult(t, rs, "Node-8")
+	expectFilterSearchResult(t, rs, "Node-9")
+	expectFilterSearchResult(t, rs, "Node-10")
+	expectFilterSearchResult(t, rs, "Node-11")
+	expectFilterSearchResult(t, rs, "Node-12")
 }
 
 // Search test helpers:

--- a/internal/search/main_test.go
+++ b/internal/search/main_test.go
@@ -400,8 +400,8 @@ func TestFilterSearchTags(t *testing.T) {
 
 	rs, _, _, _, _ := s.FilterSearch("react")
 	expectFilterSearchResult(t, rs, "Button")
-	expectFilterSearchResult(t, rs, "Form Element")
-	expectFilterSearchResult(t, rs, "Radio Button Group")
+	expectFilterSearchResult(t, rs, "Form-Element")
+	expectFilterSearchResult(t, rs, "Radio-Button-Group")
 }
 
 func TestFilterSearchMultipleTagsWithLogicalAndInQuery(t *testing.T) {
@@ -554,13 +554,13 @@ func TestFilterSearchTagsWithSpacesWhenTitleContainsSpace(t *testing.T) {
 	defer teardownSearchTest(tmp, s)
 
 	rs, _, _, _, _ := s.FilterSearch("needs")
-	expectFilterSearchResult(t, rs, "Color Definition")
+	expectFilterSearchResult(t, rs, "Color-Definition")
 
 	rs, _, _, _, _ = s.FilterSearch("images")
-	expectFilterSearchResult(t, rs, "Color Definition")
+	expectFilterSearchResult(t, rs, "Color-Definition")
 
 	rs, _, _, _, _ = s.FilterSearch("needs images")
-	expectFilterSearchResult(t, rs, "Color Definition")
+	expectFilterSearchResult(t, rs, "Color-Definition")
 }
 
 // Search test helpers:


### PR DESCRIPTION
This pull request increases the maximum number of results returned form a FilterSearch request to 100. Right now the limit is 10.

FilterSearch results are meant to be exhaustive, as described in https://rundsk.com/tree/Development/Architecture/API?t=readme§filtering-and-searching: “filter […] always returns all matched results […]”.

PTAL @mariuswilms 
Fixes #132 